### PR TITLE
Add min picture width/height filter

### DIFF
--- a/app/src/main/java/com/antony/muzei/pixiv/settings/fragments/AdvOptionsPreferenceFragment.kt
+++ b/app/src/main/java/com/antony/muzei/pixiv/settings/fragments/AdvOptionsPreferenceFragment.kt
@@ -26,7 +26,6 @@ import androidx.core.app.ActivityCompat
 import androidx.core.content.ContextCompat
 import androidx.preference.*
 import androidx.work.*
-import com.antony.muzei.pixiv.PixivProviderConst
 import com.antony.muzei.pixiv.R
 import com.antony.muzei.pixiv.provider.ClearCacheWorker
 import java.io.File
@@ -50,39 +49,22 @@ class AdvOptionsPreferenceFragment : PreferenceFragmentCompat() {
             minimumViewSliderPref.summary = (newValue as Int * 500).toString()
             true
         }
-
-        // Only enable for logged-in users
-        // width/height filter works for non logged users too
-        // but they are unable to download full sized images
-        // so it's meaningless to have it visually enabled
+        
         val minWidthSlider = findPreference<SeekBarPreference>("prefSlider_minimumWidth")
         val minHeightSlider = findPreference<SeekBarPreference>("prefSlider_minimumHeight")
 
-        // TODO: line below needs user to reload app (exit/open, kill in drawer, etc.) in order to load new value "to detect that user is logged in"
-        if(sharedPrefs.getString(PixivProviderConst.PREFERENCE_PIXIV_ACCESS_TOKEN, "").isNullOrEmpty()) {
-            minWidthSlider!!.isEnabled = false;
-            minHeightSlider!!.isEnabled = false;
+        minWidthSlider!!.updatesContinuously = true
+        minWidthSlider.summary = (sharedPrefs.getInt("prefSlider_minimumWidth", 0) * 10).toString() + "px"
+        minWidthSlider.onPreferenceChangeListener = Preference.OnPreferenceChangeListener { _: Preference?, newValue: Any ->
+            minWidthSlider.summary = (newValue as Int * 10).toString() + "px"
+            true
+        }
 
-            minWidthSlider.summary = getString(R.string.toast_loginFirst);
-            minHeightSlider.summary = getString(R.string.toast_loginFirst);
-
-        } else {
-            minWidthSlider!!.isEnabled = true;
-            minHeightSlider!!.isEnabled = true;
-
-            minWidthSlider!!.updatesContinuously = true
-            minWidthSlider.summary = (sharedPrefs.getInt("prefSlider_minimumWidth", 0) * 10).toString()+"px"
-            minWidthSlider.onPreferenceChangeListener = Preference.OnPreferenceChangeListener { _: Preference?, newValue: Any ->
-                minWidthSlider.summary = (newValue as Int * 10).toString()+"px"
-                true
-            }
-
-            minHeightSlider!!.updatesContinuously = true
-            minHeightSlider.summary = (sharedPrefs.getInt("prefSlider_minimumHeight", 0) * 10).toString()+"px"
-            minHeightSlider.onPreferenceChangeListener = Preference.OnPreferenceChangeListener { _: Preference?, newValue: Any ->
-                minHeightSlider.summary = (newValue as Int * 10).toString()+"px"
-                true
-            }
+        minHeightSlider!!.updatesContinuously = true
+        minHeightSlider.summary = (sharedPrefs.getInt("prefSlider_minimumHeight", 0) * 10).toString() + "px"
+        minHeightSlider.onPreferenceChangeListener = Preference.OnPreferenceChangeListener { _: Preference?, newValue: Any ->
+            minHeightSlider.summary = (newValue as Int * 10).toString() + "px"
+            true
         }
 
         // Maximum file size slider
@@ -161,8 +143,7 @@ class AdvOptionsPreferenceFragment : PreferenceFragmentCompat() {
         return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q && PreferenceManager.getDefaultSharedPreferences(context).getBoolean("pref_storeInExtStorage", false)) {
             val stringSet = context?.let { MediaStore.getExternalVolumeNames(it) }
             stringSet!!.size > 1
-        }
-        else {
+        } else {
             // Android P or lower
             val files: Array<File> = requireContext().getExternalFilesDirs(null)
             files.size > 1
@@ -189,8 +170,7 @@ class AdvOptionsPreferenceFragment : PreferenceFragmentCompat() {
                     .build()
             WorkManager.getInstance(requireContext())
                     .enqueueUniquePeriodicWork("PIXIV_CACHE_AUTO", ExistingPeriodicWorkPolicy.KEEP, request)
-        }
-        else {
+        } else {
             WorkManager.getInstance(requireContext()).cancelAllWorkByTag("PIXIV_CACHE_AUTO")
         }
     }

--- a/app/src/main/java/com/antony/muzei/pixiv/settings/fragments/AdvOptionsPreferenceFragment.kt
+++ b/app/src/main/java/com/antony/muzei/pixiv/settings/fragments/AdvOptionsPreferenceFragment.kt
@@ -50,6 +50,22 @@ class AdvOptionsPreferenceFragment : PreferenceFragmentCompat() {
             true
         }
 
+        val minWidthSlider = findPreference<SeekBarPreference>("prefSlider_minimumWidth")
+        minWidthSlider!!.updatesContinuously = true
+        minWidthSlider.summary = (sharedPrefs.getInt("prefSlider_minimumWidth", 0) * 10).toString()+"px"
+        minWidthSlider.onPreferenceChangeListener = Preference.OnPreferenceChangeListener { _: Preference?, newValue: Any ->
+            minWidthSlider.summary = (newValue as Int * 10).toString()+"px"
+            true
+        }
+
+        val minHeightSlider = findPreference<SeekBarPreference>("prefSlider_minimumHeight")
+        minHeightSlider!!.updatesContinuously = true
+        minHeightSlider.summary = (sharedPrefs.getInt("prefSlider_minimumHeight", 0) * 10).toString()+"px"
+        minHeightSlider.onPreferenceChangeListener = Preference.OnPreferenceChangeListener { _: Preference?, newValue: Any ->
+            minHeightSlider.summary = (newValue as Int * 10).toString()+"px"
+            true
+        }
+
         // Maximum file size slider
 //        SeekBarPreference maximumFileSizeSliderPref = findPreference("prefSlider_maxFileSize");
 //        maximumFileSizeSliderPref.setUpdatesContinuously(true);

--- a/app/src/main/java/com/antony/muzei/pixiv/settings/fragments/AdvOptionsPreferenceFragment.kt
+++ b/app/src/main/java/com/antony/muzei/pixiv/settings/fragments/AdvOptionsPreferenceFragment.kt
@@ -26,6 +26,7 @@ import androidx.core.app.ActivityCompat
 import androidx.core.content.ContextCompat
 import androidx.preference.*
 import androidx.work.*
+import com.antony.muzei.pixiv.PixivProviderConst
 import com.antony.muzei.pixiv.R
 import com.antony.muzei.pixiv.provider.ClearCacheWorker
 import java.io.File
@@ -50,20 +51,38 @@ class AdvOptionsPreferenceFragment : PreferenceFragmentCompat() {
             true
         }
 
+        // Only enable for logged-in users
+        // width/height filter works for non logged users too
+        // but they are unable to download full sized images
+        // so it's meaningless to have it visually enabled
         val minWidthSlider = findPreference<SeekBarPreference>("prefSlider_minimumWidth")
-        minWidthSlider!!.updatesContinuously = true
-        minWidthSlider.summary = (sharedPrefs.getInt("prefSlider_minimumWidth", 0) * 10).toString()+"px"
-        minWidthSlider.onPreferenceChangeListener = Preference.OnPreferenceChangeListener { _: Preference?, newValue: Any ->
-            minWidthSlider.summary = (newValue as Int * 10).toString()+"px"
-            true
-        }
-
         val minHeightSlider = findPreference<SeekBarPreference>("prefSlider_minimumHeight")
-        minHeightSlider!!.updatesContinuously = true
-        minHeightSlider.summary = (sharedPrefs.getInt("prefSlider_minimumHeight", 0) * 10).toString()+"px"
-        minHeightSlider.onPreferenceChangeListener = Preference.OnPreferenceChangeListener { _: Preference?, newValue: Any ->
-            minHeightSlider.summary = (newValue as Int * 10).toString()+"px"
-            true
+
+        // TODO: line below needs user to reload app (exit/open, kill in drawer, etc.) in order to load new value "to detect that user is logged in"
+        if(sharedPrefs.getString(PixivProviderConst.PREFERENCE_PIXIV_ACCESS_TOKEN, "").isNullOrEmpty()) {
+            minWidthSlider!!.isEnabled = false;
+            minHeightSlider!!.isEnabled = false;
+
+            minWidthSlider.summary = getString(R.string.toast_loginFirst);
+            minHeightSlider.summary = getString(R.string.toast_loginFirst);
+
+        } else {
+            minWidthSlider!!.isEnabled = true;
+            minHeightSlider!!.isEnabled = true;
+
+            minWidthSlider!!.updatesContinuously = true
+            minWidthSlider.summary = (sharedPrefs.getInt("prefSlider_minimumWidth", 0) * 10).toString()+"px"
+            minWidthSlider.onPreferenceChangeListener = Preference.OnPreferenceChangeListener { _: Preference?, newValue: Any ->
+                minWidthSlider.summary = (newValue as Int * 10).toString()+"px"
+                true
+            }
+
+            minHeightSlider!!.updatesContinuously = true
+            minHeightSlider.summary = (sharedPrefs.getInt("prefSlider_minimumHeight", 0) * 10).toString()+"px"
+            minHeightSlider.onPreferenceChangeListener = Preference.OnPreferenceChangeListener { _: Preference?, newValue: Any ->
+                minHeightSlider.summary = (newValue as Int * 10).toString()+"px"
+                true
+            }
         }
 
         // Maximum file size slider

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -48,8 +48,6 @@
     <string name="prefSummary_notLoggedIn">未登录</string>
     <string name="prefSummary_storeInExtStorage">保存在此处的图片不会自动清除</string>
     <string name="prefSummary_stuckApp">如果应用无法正常运行，请按此处</string>
-    <string name="prefSummary_minimumWidth">TODO translate: Images below set width in px will be ignored, workaround for blurry low res picture in Portrait</string>
-    <string name="prefSummary_minimumHeight">TODO translate: Images below set height in px will be ignored, workaround for blurry low res picture in Landscape</string>
 
     <string name="prefTitle_MaximumFileSize">作品最大尺寸</string>
     <string name="prefTitle_artistId">艺术家 ID</string>
@@ -69,8 +67,8 @@
     <string name="prefTitle_storeInExtStorage">图片保存到手机存储</string>
     <string name="prefTitle_storingInWhichExtStorage">正在将图片保存到</string>
     <string name="prefTitle_tagSearch">图像标签</string>
-    <string name="prefTitle_minimumWidth">TODO translate: Minimum image width</string>
-    <string name="prefTitle_minimumHeight">TODO translate: Minimum image height</string>
+    <string name="prefTitle_minimumWidth">TODO translate: Minimum picture width</string>
+    <string name="prefTitle_minimumHeight">TODO translate: Minimum picture height</string>
 
     <string name="pref_aspectRatioDefault_entryValues">0</string>
     <string name="pref_authFailActionDropDown">验证失败后措施</string>

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -48,6 +48,8 @@
     <string name="prefSummary_notLoggedIn">未登录</string>
     <string name="prefSummary_storeInExtStorage">保存在此处的图片不会自动清除</string>
     <string name="prefSummary_stuckApp">如果应用无法正常运行，请按此处</string>
+    <string name="prefSummary_minimumWidth">TODO translate: Images below set width in px will be ignored, workaround for blurry low res picture in Portrait</string>
+    <string name="prefSummary_minimumHeight">TODO translate: Images below set height in px will be ignored, workaround for blurry low res picture in Landscape</string>
 
     <string name="prefTitle_MaximumFileSize">作品最大尺寸</string>
     <string name="prefTitle_artistId">艺术家 ID</string>
@@ -67,6 +69,8 @@
     <string name="prefTitle_storeInExtStorage">图片保存到手机存储</string>
     <string name="prefTitle_storingInWhichExtStorage">正在将图片保存到</string>
     <string name="prefTitle_tagSearch">图像标签</string>
+    <string name="prefTitle_minimumWidth">TODO translate: Minimum image width</string>
+    <string name="prefTitle_minimumHeight">TODO translate: Minimum image height</string>
 
     <string name="pref_aspectRatioDefault_entryValues">0</string>
     <string name="pref_authFailActionDropDown">验证失败后措施</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -48,8 +48,6 @@
     <string name="prefSummary_notLoggedIn">Not logged in</string>
     <string name="prefSummary_storeInExtStorage">Pictures saved here will not be automatically cleared</string>
     <string name="prefSummary_stuckApp">If the app is not working, press here</string>
-    <string name="prefSummary_minimumWidth">Images below set width in px will be ignored, workaround for blurry low res picture in Portrait</string>
-    <string name="prefSummary_minimumHeight">Images below set height in px will be ignored, workaround for blurry low res picture in Landscape</string>
 
     <string name="prefTitle_MaximumFileSize">Maximum artwork size</string>
     <string name="prefTitle_artistId">Artist ID</string>
@@ -69,8 +67,8 @@
     <string name="prefTitle_storeInExtStorage">Save pictures into external storage</string>
     <string name="prefTitle_storingInWhichExtStorage">Saving pictures to</string>
     <string name="prefTitle_tagSearch">Image tag</string>
-    <string name="prefTitle_minimumWidth">Minimum image width</string>
-    <string name="prefTitle_minimumHeight">Minimum image height</string>
+    <string name="prefTitle_minimumWidth">Minimum picture width</string>
+    <string name="prefTitle_minimumHeight">Minimum picture height</string>
 
     <string name="pref_aspectRatioDefault_entryValues">0</string>
     <string name="pref_authFailActionDropDown">Authentication failure action</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -48,6 +48,8 @@
     <string name="prefSummary_notLoggedIn">Not logged in</string>
     <string name="prefSummary_storeInExtStorage">Pictures saved here will not be automatically cleared</string>
     <string name="prefSummary_stuckApp">If the app is not working, press here</string>
+    <string name="prefSummary_minimumWidth">Images below set width in px will be ignored, workaround for blurry low res picture in Portrait</string>
+    <string name="prefSummary_minimumHeight">Images below set height in px will be ignored, workaround for blurry low res picture in Landscape</string>
 
     <string name="prefTitle_MaximumFileSize">Maximum artwork size</string>
     <string name="prefTitle_artistId">Artist ID</string>
@@ -67,6 +69,8 @@
     <string name="prefTitle_storeInExtStorage">Save pictures into external storage</string>
     <string name="prefTitle_storingInWhichExtStorage">Saving pictures to</string>
     <string name="prefTitle_tagSearch">Image tag</string>
+    <string name="prefTitle_minimumWidth">Minimum image width</string>
+    <string name="prefTitle_minimumHeight">Minimum image height</string>
 
     <string name="pref_aspectRatioDefault_entryValues">0</string>
     <string name="pref_authFailActionDropDown">Authentication failure action</string>

--- a/app/src/main/res/xml/adv_setting_preference_layout.xml
+++ b/app/src/main/res/xml/adv_setting_preference_layout.xml
@@ -47,6 +47,18 @@
             android:max="100"
             android:persistent="true"
             android:title="@string/prefTitle_minimumViews" />
+        <SeekBarPreference
+            android:defaultValue="0"
+            android:key="prefSlider_minimumWidth"
+            android:max="400"
+            android:persistent="true"
+            android:title="@string/prefTitle_minimumWidth" />
+        <SeekBarPreference
+            android:defaultValue="0"
+            android:key="prefSlider_minimumHeight"
+            android:max="400"
+            android:persistent="true"
+            android:title="@string/prefTitle_minimumHeight" />
     </PreferenceCategory>
     <PreferenceCategory
         android:key="prefCat_fileOptions"


### PR DESCRIPTION
Add new filter to specify minimal picture width/height. This is a workaround for low res, and thus blurry, pictures being downloaded. Only enabled for logged users. It works for non logged users too, but it will not download full res picture, as that is only available for logged users :|

There is small issue with detecting whenever user is logged, when upon login user needs to exit/open the app for sharedresource to update. Note: AdvOptionsPreferenceFragment.kt line 61