### PR TITLE
autocrop feature

### DIFF
--- a/app/src/main/java/com/antony/muzei/pixiv/provider/PixivArtWorker.kt
+++ b/app/src/main/java/com/antony/muzei/pixiv/provider/PixivArtWorker.kt
@@ -23,6 +23,8 @@ import android.content.Context
 import android.content.Intent
 import android.content.pm.PackageManager
 import android.database.Cursor
+import android.graphics.Bitmap
+import android.graphics.BitmapFactory
 import android.net.Uri
 import android.os.Build
 import android.os.Environment
@@ -286,7 +288,74 @@ class PixivArtWorker(
                 fis.close()
             }
         }
+
+        // only available android 10+
+        if(sharedPrefs.getBoolean("pref_autoCrop", false) && Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+            cropBlankSpaceFromImage(imageInternal)
+        }
         return Uri.fromFile(imageInternal)
+    }
+
+    // stolen from https://stackoverflow.com/a/12645803
+    // ideal scenario would be to send the image url or whole file to some mini API service
+    // which would send back either signal if it's viable for cropping
+    // or whole cropped image, so we are not wasting phone battery
+    private fun cropBlankSpaceFromImage(file: File)
+    {
+        val sourceImage = BitmapFactory.decodeFile(file.path)
+        val baseColor: Int = sourceImage.getColor(0, 0).toArgb()
+
+        val width = sourceImage.width
+        val height = sourceImage.height
+
+        var isCroppable = false
+        var topY = Int.MAX_VALUE
+        var topX = Int.MAX_VALUE
+        var bottomY = -1
+        var bottomX = -1
+        for (y in 0 until height) {
+            for (x in 0 until width) {
+                if (isColorWithinTolerance(baseColor, sourceImage.getColor(x, y).toArgb())) {
+                    isCroppable = true
+                    if (x < topX) topX = x
+                    if (y < topY) topY = y
+                    if (x > bottomX) bottomX = x
+                    if (y > bottomY) bottomY = y
+                }
+            }
+        }
+
+        // sometimes it's off by 1 pixel, so these are not worth processing
+        if(!isCroppable || (topX == 0 && topY == 0 && (width == (bottomX + 1)) && (height == (bottomY + 1)))) {
+            return
+        }
+
+        // @NonNull Bitmap source, int x, int y, int width, int height
+        val croppedImage = Bitmap.createBitmap(sourceImage, topX, topY, bottomX - topX + 1, bottomY - topY + 1)
+
+        val output = FileOutputStream(file)
+        croppedImage.compress(Bitmap.CompressFormat.PNG, 85, output); // not bothering with JPEG as pixiv sends back only PNGs
+        output.close()
+    }
+
+    private fun isColorWithinTolerance(a: Int, b: Int): Boolean {
+        val aAlpha = (a and -0x1000000 ushr 24) // Alpha level
+        val aRed = (a and 0x00FF0000 ushr 16) // Red level
+        val aGreen = (a and 0x0000FF00 ushr 8) // Green level
+        val aBlue = (a and 0x000000FF) // Blue level
+        val bAlpha = (b and -0x1000000 ushr 24) // Alpha level
+        val bRed = (b and 0x00FF0000 ushr 16) // Red level
+        val bGreen = (b and 0x0000FF00 ushr 8) // Green level
+        val bBlue = (b and 0x000000FF) // Blue level
+        val distance = Math.sqrt((aAlpha - bAlpha) * (aAlpha - bAlpha) + (aRed - bRed) * (aRed - bRed) + (aGreen - bGreen) * (aGreen - bGreen) + ((aBlue - bBlue) * (aBlue - bBlue)).toDouble())
+
+        // 510.0 is the maximum distance between two colors
+        // (0,0,0,0 -> 255,255,255,255)
+        val percentAway = distance / 510.0
+
+        // tolerance 0.1 means that 2 pixel color values can be from each other up to 10% away
+        // to be considered okay for cropping
+        return percentAway > 0.10
     }
 
     // TODO is this even necessary anymore

--- a/app/src/main/java/com/antony/muzei/pixiv/provider/PixivArtWorker.kt
+++ b/app/src/main/java/com/antony/muzei/pixiv/provider/PixivArtWorker.kt
@@ -313,8 +313,8 @@ class PixivArtWorker(
         var topX = Int.MAX_VALUE
         var bottomY = -1
         var bottomX = -1
-        for (y in 0 until height) {
-            for (x in 0 until width) {
+        for (y in 0 until height step 3) {
+            for (x in 0 until width step 3) {
                 if (isColorWithinTolerance(baseColor, sourceImage.getColor(x, y).toArgb())) {
                     isCroppable = true
                     if (x < topX) topX = x
@@ -334,7 +334,7 @@ class PixivArtWorker(
         val croppedImage = Bitmap.createBitmap(sourceImage, topX, topY, bottomX - topX + 1, bottomY - topY + 1)
 
         val output = FileOutputStream(file)
-        croppedImage.compress(Bitmap.CompressFormat.PNG, 85, output); // not bothering with JPEG as pixiv sends back only PNGs
+        croppedImage.compress(Bitmap.CompressFormat.PNG, 90, output); // not bothering with JPEG as pixiv sends back only PNGs
         output.close()
     }
 

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -41,6 +41,7 @@
     <string name="prefCat_fileOptions">文件选项</string>
     <string name="prefCat_networkingOptions">网络选项</string>
     <string name="prefCat_pullFeedSettings">作品订阅设置</string>
+    <string name="prefCat_postProcess">TODO translate: Postprocessing Options</string>
 
     <string name="prefSummary_LoggedIn">已登录为</string>
     <string name="prefSummary_currentlyLoggedInAs">当前登录为</string>
@@ -48,6 +49,7 @@
     <string name="prefSummary_notLoggedIn">未登录</string>
     <string name="prefSummary_storeInExtStorage">保存在此处的图片不会自动清除</string>
     <string name="prefSummary_stuckApp">如果该应用未工作，请按此处</string>
+    <string name="prefSummary_autoCrop">TODO translate: Removes blank spaces around the picture, like white/black side bars. Only available on Android 10+.</string>
 
     <string name="prefTitle_MaximumFileSize">作品最大尺寸</string>
     <string name="prefTitle_artistId">艺术家 ID</string>
@@ -69,6 +71,7 @@
     <string name="prefTitle_tagSearch">图像标签</string>
     <string name="prefTitle_minimumWidth">最小图片宽度</string>
     <string name="prefTitle_minimumHeight">最小图片高度</string>
+    <string name="prefTitle_autoCrop">TODO translate: Auto crop</string>
 
     <string name="pref_aspectRatioDefault_entryValues">0</string>
     <string name="pref_authFailActionDropDown">验证失败后措施</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -41,6 +41,7 @@
     <string name="prefCat_fileOptions">File Options</string>
     <string name="prefCat_networkingOptions">Networking options</string>
     <string name="prefCat_pullFeedSettings">Picture feed settings</string>
+    <string name="prefCat_postProcess">Postprocessing Options</string>
 
     <string name="prefSummary_LoggedIn">Logged in as </string>
     <string name="prefSummary_currentlyLoggedInAs">"Currently logged in as "</string>
@@ -48,6 +49,7 @@
     <string name="prefSummary_notLoggedIn">Not logged in</string>
     <string name="prefSummary_storeInExtStorage">Pictures saved here will not be automatically cleared</string>
     <string name="prefSummary_stuckApp">If the app is not working, press here</string>
+    <string name="prefSummary_autoCrop">Removes blank spaces around the picture, like white/black side bars. Only available on Android 10+.</string>
 
     <string name="prefTitle_MaximumFileSize">Maximum artwork size</string>
     <string name="prefTitle_artistId">Artist ID</string>
@@ -69,6 +71,7 @@
     <string name="prefTitle_tagSearch">Image tag</string>
     <string name="prefTitle_minimumWidth">Minimum picture width</string>
     <string name="prefTitle_minimumHeight">Minimum picture height</string>
+    <string name="prefTitle_autoCrop">Auto crop</string>
 
     <string name="pref_aspectRatioDefault_entryValues">0</string>
     <string name="pref_authFailActionDropDown">Authentication failure action</string>

--- a/app/src/main/res/xml/adv_setting_preference_layout.xml
+++ b/app/src/main/res/xml/adv_setting_preference_layout.xml
@@ -95,6 +95,15 @@
             android:title="@string/prefTitle_numToDownload"
             app:min="1" />
     </PreferenceCategory>
+    <PreferenceCategory
+        android:key="prefCat_postProcess"
+        android:title="@string/prefCat_postProcess">
+        <SwitchPreference
+            android:key="pref_autoCrop"
+            android:persistent="true"
+            android:title="@string/prefTitle_autoCrop"
+            android:summary="@string/prefSummary_autoCrop" />
+    </PreferenceCategory>
     <!--    <PreferenceCategory-->
     <!--        android:key="prefCat_networkOptions"-->
     <!--        android:title="@string/prefCat_networkingOptions">-->


### PR DESCRIPTION
I got tired of hard included bars and blank spaces in images (just why would anyone do such a thing?)

Here's a feature. It may be a bit CPU intensive as it iterates over each pixel. If anyone has any better idea, fix it :D

It's optional and only available on Android 10+ (If someone wants to backport it for earlier versions, please do)

![image](https://user-images.githubusercontent.com/10332247/99904641-6b4b9c80-2ccc-11eb-893c-d9568fb1da7f.png)

Comparisons:

![Screenshot_1](https://user-images.githubusercontent.com/10332247/99904592-258ed400-2ccc-11eb-9629-932180e13931.png)
![Screenshot_2](https://user-images.githubusercontent.com/10332247/99904593-27589780-2ccc-11eb-8309-22695405f387.png)
![Screenshot_3](https://user-images.githubusercontent.com/10332247/99904594-2889c480-2ccc-11eb-9f4e-3a3436337932.png)
