### PR TITLE
Fix Simplified Chinese Translation

### DIFF
--- a/app/src/main/res/values-zh/arrays.xml
+++ b/app/src/main/res/values-zh/arrays.xml
@@ -26,9 +26,9 @@
     </string-array>
 
     <string-array name="pref_aspectRatio_entries">
-        <item>横向和纵向</item>
-        <item>横向</item>
+        <item>纵向和横向</item>
         <item>纵向</item>
+        <item>横向</item>
     </string-array>
 
     <string-array name="array_authFailActions_entries">


### PR DESCRIPTION
The order of the translation of `Portrait` and `Landscape` was wrong...