### PR TITLE
fix: OkHttpClient Instance didn't update in time when pref_enableNetworkBypass change.  #162

### DIFF
--- a/app/src/main/java/com/antony/muzei/pixiv/provider/PixivArtWorker.kt
+++ b/app/src/main/java/com/antony/muzei/pixiv/provider/PixivArtWorker.kt
@@ -79,6 +79,7 @@ class PixivArtWorker(context: Context, params: WorkerParameters) : Worker(contex
         private var clearArtwork = false
 
         fun enqueueLoad(clear: Boolean, context: Context?) {
+            Log.d(LOG_TAG,"Enqueued load")
             if (clear) {
                 clearArtwork = true
             }

--- a/app/src/main/java/com/antony/muzei/pixiv/provider/network/OkHttpSingleton.kt
+++ b/app/src/main/java/com/antony/muzei/pixiv/provider/network/OkHttpSingleton.kt
@@ -1,6 +1,7 @@
 package com.antony.muzei.pixiv.provider.network
 
 import android.annotation.SuppressLint
+import android.util.Log
 import androidx.preference.PreferenceManager
 import com.antony.muzei.pixiv.BuildConfig
 import com.antony.muzei.pixiv.PixivMuzei
@@ -10,6 +11,7 @@ import java.security.cert.X509Certificate
 import javax.net.ssl.X509TrustManager
 
 object OkHttpSingleton {
+    private const val LOG_TAG = "OkHttpSingleton"
     private val x509TrustManager: X509TrustManager = object : X509TrustManager {
         @SuppressLint("TrustAllX509TrustManager")
         override fun checkClientTrusted(x509Certificates: Array<X509Certificate>, s: String) {
@@ -40,7 +42,9 @@ object OkHttpSingleton {
                 .retryOnConnectionFailure(true)
                 .apply {
                     val prefs = PreferenceManager.getDefaultSharedPreferences(PixivMuzei.context?.applicationContext)
-                    if (prefs.getBoolean("pref_enableNetworkBypass", false)) {
+                    val enableNetworkBypass = prefs.getBoolean("pref_enableNetworkBypass", false)
+                    Log.d(LOG_TAG,"network bypass was $enableNetworkBypass")
+                    if (enableNetworkBypass) {
                         sslSocketFactory(RubySSLSocketFactory(), x509TrustManager)
                         dns(RubyHttpDns.getInstance())
                     }
@@ -50,5 +54,11 @@ object OkHttpSingleton {
                 .build()
         }
         return instance as OkHttpClient
+    }
+
+    fun refreshInstance(){
+        // Through set it to null, the OkHttpClient will be create again and apply with new preference when `getInstance` was invoked.
+        instance = null
+        Log.d(LOG_TAG,"set OkHttp instance to null")
     }
 }

--- a/app/src/main/java/com/antony/muzei/pixiv/provider/network/RestClient.kt
+++ b/app/src/main/java/com/antony/muzei/pixiv/provider/network/RestClient.kt
@@ -23,7 +23,7 @@ import retrofit2.Retrofit
 import retrofit2.converter.moshi.MoshiConverterFactory
 
 object RestClient {
-    private val okHttpClientAuthBuilder = OkHttpSingleton.getInstance().newBuilder()
+    private val okHttpClientAuthBuilder get() = OkHttpSingleton.getInstance().newBuilder()
         .apply {
             addNetworkInterceptor(PixivAuthHeaderInterceptor())
             //addInterceptor(CustomClientHeaderInterceptor())

--- a/app/src/main/java/com/antony/muzei/pixiv/settings/fragments/AdvOptionsPreferenceFragment.kt
+++ b/app/src/main/java/com/antony/muzei/pixiv/settings/fragments/AdvOptionsPreferenceFragment.kt
@@ -29,6 +29,8 @@ import androidx.preference.*
 import androidx.work.*
 import com.antony.muzei.pixiv.R
 import com.antony.muzei.pixiv.provider.ClearCacheWorker
+import com.antony.muzei.pixiv.provider.PixivArtWorker
+import com.antony.muzei.pixiv.provider.network.OkHttpSingleton
 import java.text.SimpleDateFormat
 import java.util.*
 import java.util.concurrent.TimeUnit
@@ -172,6 +174,15 @@ class AdvOptionsPreferenceFragment : PreferenceFragmentCompat() {
             true
         }
 
+        val enableNetworkPassbyCheckbox = findPreference<SwitchPreference>("pref_enableNetworkBypass")!!
+        enableNetworkPassbyCheckbox.setOnPreferenceChangeListener { _, _ ->
+
+            OkHttpSingleton.refreshInstance() // Renew a instance with sslSocketFactory by this
+
+            PixivArtWorker.enqueueLoad(false, context)
+
+            true
+        }
         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.Q) {
             preferenceScreen = findPreference(resources.getString(R.string.preferenceScreen))
             val prefCatPostProcess = findPreference<PreferenceCategory>("prefCat_postProcess")


### PR DESCRIPTION
Hi!
This is a fix of issue https://github.com/yellowbluesky/PixivforMuzei3/issues/162

I found this bug is caused by the OKHttpClient instance is a singleton and it can not be changed by any preferences after the app was started.  I fix it by setting the instance to null after preferences changed so the instance will be applied with `sslSocketFactory` and `dns` method on the next request.