### PR TITLE
feat: provide a config item for pixiv.cat proxy feature which already exists

### DIFF
--- a/app/src/main/java/com/antony/muzei/pixiv/util/HostManager.java
+++ b/app/src/main/java/com/antony/muzei/pixiv/util/HostManager.java
@@ -1,8 +1,13 @@
 package com.antony.muzei.pixiv.util;
 
 
+import android.content.SharedPreferences;
 import android.net.Uri;
 import android.text.TextUtils;
+
+import androidx.preference.PreferenceManager;
+
+import com.antony.muzei.pixiv.PixivMuzei;
 
 import java.util.Random;
 
@@ -76,7 +81,14 @@ public class HostManager {
     }
 
     public String replaceUrl(String before) {
+        // See https://pixiv.cat/reverseproxy.html
+        // Its ISP is Cloudflare
         boolean usePixivCatProxy = false;
+        if(PixivMuzei.Companion.getContext() != null){
+            SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(PixivMuzei.Companion.getContext().getApplicationContext());
+            usePixivCatProxy = prefs.getBoolean("pref_usePixivCat",false);
+        }
+
         if (usePixivCatProxy) {
             return before.replace(HOST_OLD, HOST_NEW);
         } else {

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -76,6 +76,7 @@
     <string name="pref_aspectRatioDefault_entryValues">0</string>
     <string name="pref_authFailActionDropDown">验证失败后措施</string>
     <string name="prefTitle_enableNetworkBypass">绕过网络过滤</string><!--指绕过大陆封锁所用技术，参见 https://gulut.github.io/gulut-blog/post1/2020/05/31/2020-05-31-by-pass-the-gfw-by-sni-->
+    <string name="prefTitle_usePixivCat">使用 PixivCat 反向代理</string>
     <string name="pref_updateMode">更新模式</string>
     <string name="pref_updateMode_default">daily_rank</string>
 
@@ -110,4 +111,5 @@
     <string name="prefTitle_mobileDataSaver">移动数据省流</string>
     <string name="prefSummary_mobileDataSaver">停止下载新作品</string>
     <string name="prefCat_appSettings">应用设置</string>
+    <string name="prefSummary_usePixivCat">加速某些地区的图片下载</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -76,7 +76,7 @@
     <string name="pref_aspectRatioDefault_entryValues">0</string>
     <string name="pref_authFailActionDropDown">Authentication failure action</string>
     <string name="prefTitle_enableNetworkBypass">Enable network filter bypass</string>
-    <string name="prefTitle_usePixivCat">Use pixiv cat for peverse proxy</string>
+    <string name="prefTitle_usePixivCat">Use pixiv.cat reverse proxy for image downloads</string>
     <string name="pref_updateMode">Update mode</string>
     <string name="pref_updateMode_default">daily_rank</string>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -114,6 +114,6 @@
     <string name="prefSummary_mobileDataSaver">Stops new artworks from being downloaded</string>
     <string name="prefCat_appSettings">App settings</string>
     <string name="prefSummary_enableNetworkBypass">Disable if you are having problems on VPN</string>
-    <string name="prefSummary_usePixivCat">Speed up image download in some areas</string>
+    <string name="prefSummary_usePixivCat">May speed up image downloads in some areas</string>
 
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -76,6 +76,7 @@
     <string name="pref_aspectRatioDefault_entryValues">0</string>
     <string name="pref_authFailActionDropDown">Authentication failure action</string>
     <string name="prefTitle_enableNetworkBypass">Enable network filter bypass</string>
+    <string name="prefTitle_usePixivCat">Use pixiv cat for peverse proxy</string>
     <string name="pref_updateMode">Update mode</string>
     <string name="pref_updateMode_default">daily_rank</string>
 
@@ -113,4 +114,6 @@
     <string name="prefSummary_mobileDataSaver">Stops new artworks from being downloaded</string>
     <string name="prefCat_appSettings">App settings</string>
     <string name="prefSummary_enableNetworkBypass">Disable if you are having problems on VPN</string>
+    <string name="prefSummary_usePixivCat">Speed up image download in some areas</string>
+
 </resources>

--- a/app/src/main/res/xml/adv_setting_preference_layout.xml
+++ b/app/src/main/res/xml/adv_setting_preference_layout.xml
@@ -130,5 +130,10 @@
         android:persistent="true"
         android:summary="@string/prefSummary_enableNetworkBypass"
         android:title="@string/prefTitle_enableNetworkBypass" />
+    <SwitchPreference
+        android:key="pref_usePixivCat"
+        android:persistent="true"
+        android:summary="@string/prefSummary_usePixivCat"
+        android:title="@string/prefTitle_usePixivCat" />
     <!--    </PreferenceCategory>-->
 </PreferenceScreen>


### PR DESCRIPTION
Here the feature already exists but never be enabled.
https://github.com/yellowbluesky/PixivforMuzei3/blob/59a3834fb77a71642e0ac112783e2a87cc82781a/app/src/main/java/com/antony/muzei/pixiv/util/HostManager.java#L78-L85

`pixiv.cat` can be used to reverse proxy, see https://pixiv.cat/reverseproxy.html for more infomation. Its ISP is Cloudflare so it can be used to speed up the download of images in some area

Besides, I am not sure if my expression in `app/src/main/res/values/strings.xml` is accurate since my English is poor, maybe it needs to edit for proper expression
