### PR TITLE
Update proguard-rules.pro

### DIFF
--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -4,3 +4,5 @@
 -dontwarn org.graalvm.nativeimage.hosted.RuntimeResourceAccess
 -dontwarn retrofit2.**
 -keep class retrofit2.** { *; }
+-keeppackagenames okhttp3.internal.publicsuffix.*
+-adaptresourcefilenames okhttp3/internal/publicsuffix/PublicSuffixDatabase.gz


### PR DESCRIPTION
Sorry for my mistake at last commit. I just realized that in prodRelease okhttp-dnsoverhttps won't work at all when this file was not kept. Found this when trying to favorite an artwork in Muzei, NoSuchFileException in logs.