### PR TITLE
Fix IndexOutOfBoundsException on bulk delete

### DIFF
--- a/app/src/main/java/com/antony/muzei/pixiv/settings/deleteArtwork/ArtworkDeletionAdapter.kt
+++ b/app/src/main/java/com/antony/muzei/pixiv/settings/deleteArtwork/ArtworkDeletionAdapter.kt
@@ -44,12 +44,13 @@ class ArtworkDeletionAdapter(private val artworkItems: MutableList<ArtworkItem>)
         return artworkItems.size
     }
 
-    fun removeItems(artworkItemsToDelete: List<ArtworkItem>, positionsToDelete: List<Int>) {
+    fun removeItems(artworkItemsToDelete: List<ArtworkItem>) {
+        val positionsToDelete = artworkItemsToDelete.mapNotNull { item ->
+            artworkItems.indexOf(item).takeIf { it != -1 }
+        }.sortedDescending()
         artworkItems.removeAll(artworkItemsToDelete)
-        for ((deleteCount, position) in positionsToDelete.withIndex()) {
-            // With each deletion, the backing artworkItems list shifts in size.
-            // If we do not offset the deletion index, we will quickly encounter IndexOutOfBounds errors
-            notifyItemRemoved(position - deleteCount)
+        for (position in positionsToDelete) {
+            notifyItemRemoved(position)
         }
     }
 
@@ -85,12 +86,10 @@ class ArtworkDeletionAdapter(private val artworkItems: MutableList<ArtworkItem>)
                 // We can access the data within the views
                 if (!mArtworkItem.selected) {
                     ArtworkDeletionFragment.SELECTED_ITEMS.add(mArtworkItem)
-                    ArtworkDeletionFragment.SELECTED_POSITIONS.add(position)
                     mImageView.setColorFilter(Color.argb(130, Color.red(color), Color.green(color), Color.blue(color)))
                     mArtworkItem.selected = true
                 } else {
                     ArtworkDeletionFragment.SELECTED_ITEMS.remove(mArtworkItem)
-                    ArtworkDeletionFragment.SELECTED_POSITIONS.remove(position)
                     mImageView.clearColorFilter()
                     mArtworkItem.selected = false
                 }

--- a/app/src/main/java/com/antony/muzei/pixiv/settings/deleteArtwork/ArtworkDeletionFragment.kt
+++ b/app/src/main/java/com/antony/muzei/pixiv/settings/deleteArtwork/ArtworkDeletionFragment.kt
@@ -44,7 +44,6 @@ import kotlin.math.ceil
 class ArtworkDeletionFragment : Fragment() {
     companion object {
         val SELECTED_ITEMS = mutableListOf<ArtworkItem>()
-        val SELECTED_POSITIONS = mutableListOf<Int>()
     }
 
     override fun onCreateView(
@@ -80,8 +79,7 @@ class ArtworkDeletionFragment : Fragment() {
             val numberDeleted = SELECTED_ITEMS.size
 
             // Deletes the artwork items from the ArrayList used as backing for the RecyclerView
-            adapter.removeItems(SELECTED_ITEMS, SELECTED_POSITIONS)
-            SELECTED_POSITIONS.clear()
+            adapter.removeItems(SELECTED_ITEMS)
 
             // We insert the deleted artwork ID's
             val listOfDeletedIds: MutableList<DeletedArtworkIdEntity> = mutableListOf()


### PR DESCRIPTION
This patch tries to fix a crash when a user tries to delete more than 2 artworks at one time, by sorting items in descending order before delete action.

The error looks like this, can confirm it on my Google Pixel 5, Android 14 device:

```
31:53.032 32393-32393 AndroidRuntime          com.antony.muzei.pixiv               E  FATAL EXCEPTION: main
Process: com.antony.muzei.pixiv, PID: 32393
java.lang.IndexOutOfBoundsException: Inconsistency detected. Invalid view holder adapter positiona{2b9bce1 position=-1 id=-1, oldPos=3, pLpos:1 scrap [attachedScrap] tmpDetached no parent} androidx.recyclerview.widget.RecyclerView{e333797 VFED.V... ......I. 44,0-1036,2072 #7f0900f4 app:id/list}, adapter:q2.b@773de7e, layout:androidx.recyclerview.widget.GridLayoutManager@c88dd84, context:com.antony.muzei.pixiv.settings.MainActivity@e3df323
	at androidx.recyclerview.widget.RecyclerView$Recycler.validateViewHolderForOffsetPosition(RecyclerView.java)
	at androidx.recyclerview.widget.RecyclerView$Recycler.tryGetViewHolderForPositionByDeadline(RecyclerView.java)
	at androidx.recyclerview.widget.RecyclerView$Recycler.getViewForPosition(RecyclerView.java)
	at androidx.recyclerview.widget.RecyclerView$Recycler.getViewForPosition(RecyclerView.java)
	at androidx.recyclerview.widget.LinearLayoutManager$LayoutState.next(LinearLayoutManager.java)
	at androidx.recyclerview.widget.GridLayoutManager.layoutChunk(GridLayoutManager.java)
	at androidx.recyclerview.widget.LinearLayoutManager.fill(LinearLayoutManager.java)
	at androidx.recyclerview.widget.LinearLayoutManager.onLayoutChildren(LinearLayoutManager.java)
	at androidx.recyclerview.widget.GridLayoutManager.onLayoutChildren(GridLayoutManager.java)
	at androidx.recyclerview.widget.RecyclerView.dispatchLayoutStep1(RecyclerView.java)
	at androidx.recyclerview.widget.RecyclerView.s(RecyclerView.java:64)
	at androidx.recyclerview.widget.RecyclerView.onLayout(RecyclerView.java)
	at android.view.View.layout(View.java:24722)
	at android.view.ViewGroup.layout(ViewGroup.java:6450)
	at android.widget.FrameLayout.layoutChildren(FrameLayout.java:332)
	at android.widget.FrameLayout.onLayout(FrameLayout.java:270)
	at android.view.View.layout(View.java:24722)
	at android.view.ViewGroup.layout(ViewGroup.java:6450)
	at android.widget.FrameLayout.layoutChildren(FrameLayout.java:332)
	at android.widget.FrameLayout.onLayout(FrameLayout.java:270)
	at android.view.View.layout(View.java:24722)
	at android.view.ViewGroup.layout(ViewGroup.java:6450)
	at androidx.recyclerview.widget.RecyclerView$LayoutManager.layoutDecoratedWithMargins(RecyclerView.java)
	at androidx.recyclerview.widget.LinearLayoutManager.layoutChunk(LinearLayoutManager.java)
	at androidx.recyclerview.widget.LinearLayoutManager.fill(LinearLayoutManager.java)
	at androidx.recyclerview.widget.LinearLayoutManager.onLayoutChildren(LinearLayoutManager.java)
	at androidx.recyclerview.widget.RecyclerView.dispatchLayoutStep2(RecyclerView.java)
	at androidx.recyclerview.widget.RecyclerView.s(RecyclerView.java:72)
	at androidx.recyclerview.widget.RecyclerView.onLayout(RecyclerView.java)
	at android.view.View.layout(View.java:24722)
	at android.view.ViewGroup.layout(ViewGroup.java:6450)
	at androidx.viewpager2.widget.ViewPager2.onLayout(ViewPager2.java:60)
	at android.view.View.layout(View.java:24722)
	at android.view.ViewGroup.layout(ViewGroup.java:6450)
	at com.google.android.material.appbar.HeaderScrollingViewBehavior.layoutChild(HeaderScrollingViewBehavior.java)
	at com.google.android.material.appbar.ViewOffsetBehavior.h(ViewOffsetBehavior.java:1)
	at androidx.coordinatorlayout.widget.CoordinatorLayout.onLayout(CoordinatorLayout.java)
	at android.view.View.layout(View.java:24722)
	at android.view.ViewGroup.layout(ViewGroup.java:6450)
	at android.widget.FrameLayout.layoutChildren(FrameLayout.java:332)
	at android.widget.FrameLayout.onLayout(FrameLayout.java:270)
	at android.view.View.layout(View.java:24722)
	at android.view.ViewGroup.layout(ViewGroup.java:6450)
	at android.widget.LinearLayout.setChildFrame(LinearLayout.java:1891)
	at android.widget.LinearLayout.layoutVertical(LinearLayout.java:1729)
	at android.widget.LinearLayout.onLayout(LinearLayout.java:1638)
	at android.view.View.layout(View.java:24722)
	at android.view.ViewGroup.layout(ViewGroup.java:6450)
	at android.widget.FrameLayout.layoutChildren(FrameLayout.java:332)
	at android.widget.FrameLayout.onLayout(FrameLayout.java:270)
	at android.view.View.layout(View.java:24722)
	at android.view.ViewGroup.layout(ViewGroup.java:6450)
	at android.widget.LinearLayout.setChildFrame(LinearLayout.java:1891)
	at android.widget.LinearLayout.layoutVertical(LinearLayout.java:1729)
	at android.widget.LinearLayout.onLayout(LinearLayout.java:1638)
	at android.view.View.layout(View.java:24722)
	at android.view.ViewGroup.layout(ViewGroup.java:6450)
	at android.widget.FrameLayout.layoutChildren(FrameLayout.java:332)
	at android.widget.FrameLayout.onLayout(FrameLayout.java:270)
	at com.android.internal.policy.DecorView.onLayout(DecorView.java:807)
	at android.view.View.layout(View.java:24722)
	at android.view.ViewGroup.layout(ViewGroup.java:6450)
	at android.view.ViewRootImpl.performLayout(ViewRootImpl.java:4485)
31:53.032 32393-32393 AndroidRuntime          com.antony.muzei.pixiv               E  	at android.view.ViewRootImpl.performTraversals(ViewRootImpl.java:3786)
	at android.view.ViewRootImpl.doTraversal(ViewRootImpl.java:2659)
	at android.view.ViewRootImpl$TraversalRunnable.run(ViewRootImpl.java:9789)
	at android.view.Choreographer$CallbackRecord.run(Choreographer.java:1399)
	at android.view.Choreographer$CallbackRecord.run(Choreographer.java:1408)
	at android.view.Choreographer.doCallbacks(Choreographer.java:1008)
	at android.view.Choreographer.doFrame(Choreographer.java:938)
	at android.view.Choreographer$FrameDisplayEventReceiver.run(Choreographer.java:1382)
	at android.os.Handler.handleCallback(Handler.java:959)
	at android.os.Handler.dispatchMessage(Handler.java:100)
	at android.os.Looper.loopOnce(Looper.java:232)
	at android.os.Looper.loop(Looper.java:317)
	at android.app.ActivityThread.main(ActivityThread.java:8501)
	at java.lang.reflect.Method.invoke(Native Method)
	at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:552)
	at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:878)
```

Please review it and test both the crash before and the fix.