### PR TITLE
Replace i.pixiv.cat with i.pixiv.re for Chinese user

### DIFF
--- a/app/src/main/java/com/antony/muzei/pixiv/util/HostManager.java
+++ b/app/src/main/java/com/antony/muzei/pixiv/util/HostManager.java
@@ -26,7 +26,7 @@ public class HostManager {
 
     public static final String HOST_OLD = "i.pximg.net";
     //    public static final String HOST_OLD = "app-api.pixiv.net";
-    public static final String HOST_NEW = "i.pixiv.cat";
+    public static final String HOST_NEW = "i.pixiv.re";
     private static final String HTTP_HEAD = "http://";
 
     private String host;


### PR DESCRIPTION
The main domain "i.pixiv.cat" is blocked in mainland China. It is recommended to use i.pixiv.re instead, which does not affect usage in other regions.