### PR TITLE
Bookmark enhancements

### DIFF
--- a/app/src/main/java/com/antony/muzei/pixiv/provider/AddToBookmarkService.kt
+++ b/app/src/main/java/com/antony/muzei/pixiv/provider/AddToBookmarkService.kt
@@ -68,7 +68,7 @@ class AddToBookmarkService : Service() {
 
                 val formBody = FormBody.Builder()
                     .add("illust_id", intent.getStringExtra("artworkId")!!)
-                    .add("restrict", "public")
+                    .add("restrict", if (intent.getBooleanExtra("isPrivate", false)) "private" else "public")
                     .build()
 
                 val request = Request.Builder()

--- a/app/src/main/java/com/antony/muzei/pixiv/provider/AddToBookmarkService.kt
+++ b/app/src/main/java/com/antony/muzei/pixiv/provider/AddToBookmarkService.kt
@@ -23,7 +23,9 @@ import android.content.Intent
 import android.content.pm.ServiceInfo.FOREGROUND_SERVICE_TYPE_DATA_SYNC
 import android.os.Build
 import android.os.IBinder
+import android.widget.Toast
 import androidx.core.app.NotificationCompat
+import com.antony.muzei.pixiv.PixivMuzeiSupervisor
 import com.antony.muzei.pixiv.R
 import com.antony.muzei.pixiv.provider.network.OkHttpSingleton
 import com.antony.muzei.pixiv.provider.network.interceptor.PixivAuthHeaderInterceptor
@@ -76,7 +78,28 @@ class AddToBookmarkService : Service() {
                     .post(formBody)
                     .build()
 
-                imageHttpClient.newCall(request).execute()
+                imageHttpClient.newCall(request).execute().use { response ->
+                    if (response.isSuccessful) {
+                        PixivMuzeiSupervisor.post(Runnable {
+                            Toast.makeText(
+                                applicationContext,
+                                if (intent.getBooleanExtra("isPrivate", false))
+                                    R.string.toast_bookmark_private_success
+                                else
+                                    R.string.toast_bookmark_success,
+                                Toast.LENGTH_SHORT
+                            ).show()
+                        })
+                    } else {
+                        PixivMuzeiSupervisor.post(Runnable {
+                            Toast.makeText(
+                                applicationContext,
+                                R.string.toast_bookmark_failure,
+                                Toast.LENGTH_SHORT
+                            ).show()
+                        })
+                    }
+                }
             }
         } catch (ex: IOException) {
             ex.printStackTrace()

--- a/app/src/main/java/com/antony/muzei/pixiv/provider/MuzeiCommandManager.kt
+++ b/app/src/main/java/com/antony/muzei/pixiv/provider/MuzeiCommandManager.kt
@@ -50,11 +50,13 @@ import java.io.File
 class MuzeiCommandManager {
 
     companion object {
-        const val COMMAND_ADD_TO_BOOKMARKS = 517
-        const val COMMAND_ADD_TO_PRIVATE_BOOKMARKS = 518
         const val COMMAND_VIEW_IMAGE_DETAILS = 988
         const val COMMAND_SHARE_IMAGE = 883
-        const val COMMAND_BLOCK_ARTIST = 765
+
+        private const val ACTION_ADD_TO_BOOKMARK = "${BuildConfig.APPLICATION_ID}.action.ADD_TO_BOOKMARK"
+        private const val ACTION_ADD_TO_PRIVATE_BOOKMARK = "${BuildConfig.APPLICATION_ID}.action.ADD_TO_PRIVATE_BOOKMARK"
+        private const val ACTION_DELETE_ARTWORK = "${BuildConfig.APPLICATION_ID}.action.DELETE_ARTWORK"
+        private const val ACTION_BLOCK_ARTIST = "${BuildConfig.APPLICATION_ID}.action.BLOCK_ARTIST"
     }
 
     fun provideActions(context: Context, artwork: Artwork): List<RemoteActionCompat> {
@@ -171,6 +173,7 @@ class MuzeiCommandManager {
         artwork: Artwork
     ): RemoteActionCompat =
         Intent(context, AddToBookmarkService::class.java).apply {
+            action = ACTION_ADD_TO_BOOKMARK
             putExtra("artworkId", artwork.token.toString())
             putExtra("accessToken", getAccessToken())
             putExtra("artworkTitle", artwork.title)
@@ -179,7 +182,7 @@ class MuzeiCommandManager {
         }.let { intent ->
             PendingIntent.getService(
                 context,
-                0,
+                artwork.id.toInt(),
                 intent,
                 PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_UPDATE_CURRENT
             )
@@ -201,6 +204,7 @@ class MuzeiCommandManager {
         artwork: Artwork
     ): RemoteActionCompat =
         Intent(context, AddToBookmarkService::class.java).apply {
+            action = ACTION_ADD_TO_PRIVATE_BOOKMARK
             putExtra("artworkId", artwork.token.toString())
             putExtra("accessToken", getAccessToken())
             putExtra("artworkTitle", artwork.title)
@@ -209,7 +213,7 @@ class MuzeiCommandManager {
         }.let { intent ->
             PendingIntent.getService(
                 context,
-                COMMAND_ADD_TO_PRIVATE_BOOKMARKS,
+                artwork.id.toInt(),
                 intent,
                 PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_UPDATE_CURRENT
             )
@@ -227,11 +231,12 @@ class MuzeiCommandManager {
 
     private fun obtainActionDeleteArtwork(context: Context, artwork: Artwork): RemoteActionCompat =
         Intent(context, DeleteArtworkReceiver::class.java).apply {
+            action = ACTION_DELETE_ARTWORK
             putExtra("artworkId", artwork.token)
         }.let { intent ->
             PendingIntent.getBroadcast(
                 context,
-                0,
+                artwork.id.toInt(),
                 intent,
                 PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_UPDATE_CURRENT
             )
@@ -249,11 +254,12 @@ class MuzeiCommandManager {
 
     private fun obtainActionBlockArtist(context: Context, artwork: Artwork): RemoteActionCompat =
         Intent(context, BlockArtistReceiver::class.java).apply {
+            action = ACTION_BLOCK_ARTIST
             putExtra("artistId", artwork.metadata)
         }.let { intent ->
             PendingIntent.getBroadcast(
                 context,
-                0,
+                artwork.id.toInt(),
                 intent,
                 PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_UPDATE_CURRENT
             )

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -18,6 +18,7 @@
     <string name="button_clearCache">清除图像缓存</string>
 
     <string name="command_addToBookmark">收藏</string>
+    <string name="command_addToPrivateBookmark">非公开收藏</string>
     <string name="command_delete_artwork">删除作品</string>
     <string name="command_shareImage">分享图像</string>
     <string name="command_viewArtworkDetails">查看详情</string>
@@ -102,6 +103,9 @@
     <string name="toast_newFilterSelect">过滤选择更新，清除图像缓存</string>
     <string name="toast_newTag">搜索标签更新，清除图像缓存</string>
     <string name="toast_newUpdateMode">模式更新，清除图像缓存</string>
+    <string name="toast_bookmark_success">收藏成功</string>
+    <string name="toast_bookmark_private_success">非公开收藏成功</string>
+    <string name="toast_bookmark_failure">收藏失败</string>
 
     <string name="login_pixiv_refresh_hint">刷新令牌</string>
     <string name="action_sign_in_refresh">刷新令牌以登录</string><!--Refresh Token 用作刷新 Access Token，为 OAuth 中一项术语，此处翻译不确定-->

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -106,6 +106,10 @@
     <string name="toast_newFilterSelect">New filter selection, clearing image cache</string>
     <string name="toast_newTag">New search tag, clearing image cache</string>
     <string name="toast_newUpdateMode">New update mode, clearing image cache</string>
+    <string name="toast_bookmark_success">Added to bookmarks</string>
+    <string name="toast_bookmark_private_success">Added to private bookmarks</string>
+    <string name="toast_bookmark_failure">Failed to add to bookmarks</string>
+
     <string name="preferenceScreen">preferenceScreen</string>
     <string name="login_pixiv_refresh_hint">Refresh Token</string>
     <string name="action_sign_in_refresh">Login using refresh token</string>
@@ -117,8 +121,4 @@
     <string name="prefSummary_enableNetworkBypass">Disable if you are having problems on VPN</string>
     <string name="prefSummary_usePixivCat">May speed up image downloads in some areas</string>
     <string name="prefTitle_tagLanguage">Tag language</string>
-    <string name="toast_bookmark_success">Added to bookmarks</string>
-    <string name="toast_bookmark_private_success">Added to private bookmarks</string>
-    <string name="toast_bookmark_failure">Failed to add to bookmarks</string>
-
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -18,6 +18,7 @@
     <string name="button_clearCache">Immediately clear image cache</string>
 
     <string name="command_addToBookmark">Add to bookmarks</string>
+    <string name="command_addToPrivateBookmark">Bookmark privately</string>
     <string name="command_delete_artwork">Delete this artwork</string>
     <string name="command_shareImage">Share image</string>
     <string name="command_viewArtworkDetails">Show details</string>
@@ -116,5 +117,8 @@
     <string name="prefSummary_enableNetworkBypass">Disable if you are having problems on VPN</string>
     <string name="prefSummary_usePixivCat">May speed up image downloads in some areas</string>
     <string name="prefTitle_tagLanguage">Tag language</string>
+    <string name="toast_bookmark_success">Added to bookmarks</string>
+    <string name="toast_bookmark_private_success">Added to private bookmarks</string>
+    <string name="toast_bookmark_failure">Failed to add to bookmarks</string>
 
 </resources>


### PR DESCRIPTION
- Allow adding to private bookmarks
- Show bookmark result in Toast
- Fix wrong artwork are being operated in Muzei gallery
   - Example: Muzei -> Sources -> Browse -> Long press on an artwork -> Delete this artwork, a wrong art is being deleted.

Issues that may need to be addressed:
Since the app has no notification permissions (`android.permission.POST_NOTIFICATIONS`), some toasts may be blocked by Android (`suppressing toast from package *** by user request`).