### PR TITLE
Enable edge to edge and fix status bar overlapping and text/background conflict

### DIFF
--- a/app/src/main/java/com/antony/muzei/pixiv/login/LoginActivityWebview.kt
+++ b/app/src/main/java/com/antony/muzei/pixiv/login/LoginActivityWebview.kt
@@ -33,6 +33,7 @@ import android.util.Log
 import android.webkit.WebResourceRequest
 import android.webkit.WebView
 import android.webkit.WebViewClient
+import androidx.activity.enableEdgeToEdge
 import androidx.preference.PreferenceManager
 import com.antony.muzei.pixiv.BuildConfig
 import com.antony.muzei.pixiv.PixivProviderConst
@@ -65,6 +66,7 @@ class LoginActivityWebview : PixivMuzeiActivity(),
     private var mBinding: ActivityLoginWebviewBinding? = null
 
     override fun onCreate(savedInstanceState: Bundle?) {
+        enableEdgeToEdge()
         super.onCreate(savedInstanceState)
         mBinding = ActivityLoginWebviewBinding.inflate(layoutInflater)
         setContentView(R.layout.activity_login_webview)

--- a/app/src/main/java/com/antony/muzei/pixiv/settings/MainActivity.kt
+++ b/app/src/main/java/com/antony/muzei/pixiv/settings/MainActivity.kt
@@ -21,6 +21,7 @@ import android.content.Intent
 import android.content.pm.PackageManager
 import android.net.Uri
 import android.os.Bundle
+import androidx.activity.enableEdgeToEdge
 import androidx.appcompat.app.AlertDialog
 import androidx.appcompat.app.AppCompatDelegate
 import androidx.viewpager2.widget.ViewPager2
@@ -35,6 +36,7 @@ import com.google.android.material.tabs.TabLayoutMediator
 
 class MainActivity : PixivMuzeiActivity(), AdvOptionsPreferenceFragment.NightModePreferenceListener {
     override fun onCreate(savedInstanceState: Bundle?) {
+        enableEdgeToEdge()
         super.onCreate(savedInstanceState)
 
         val tabTitles = intArrayOf(

--- a/app/src/main/res/layout/activity_login_webview.xml
+++ b/app/src/main/res/layout/activity_login_webview.xml
@@ -4,7 +4,8 @@
     android:id="@+id/webviewConstraintLayout"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    tools:context=".login.LoginActivityWebview">
+    tools:context=".login.LoginActivityWebview"
+    android:fitsSystemWindows="true">
 
     <WebView
         android:id="@+id/webview"

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -25,7 +25,8 @@
     <com.google.android.material.appbar.AppBarLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:theme="@style/AppTheme">
+        android:theme="@style/AppTheme"
+        android:fitsSystemWindows="true">
 
         <TextView
             android:id="@+id/title"
@@ -36,7 +37,8 @@
             android:padding="@dimen/appbar_padding"
             android:text="@string/app_name"
             android:textAppearance="@style/TextAppearance.Widget.AppCompat.Toolbar.Title"
-            app:layout_scrollFlags="scroll|snap" />
+            app:layout_scrollFlags="scroll|snap"
+            app:layout_scrollEffect="compress" />
 
         <com.google.android.material.tabs.TabLayout
             android:id="@+id/tabs"


### PR DESCRIPTION
Android 15+ forces [edge to edge](https://developer.android.com/develop/ui/views/layout/edge-to-edge) and that caused the title to overlap the status bar. Might as well adapt edge to edge for all android versions to have consistent design. Also fixes the text/background conflict from recent Android versions (at least on Android 14, it depends on light/dark and dynamic wallpaper colors).

Compress scroll effect is needed, so the title doesn't touch the status bar when scrolling.

Pictures are from emulators (tested oldest supported and recent ones) and override display cutout to different ones in developer settings to better visualize:

Before (Android versions):
| 5 | 14 | 15 - 16 |
| --- | --- | --- |
| ![image](https://github.com/user-attachments/assets/acb9be10-66ff-44cf-b0d2-8f230057f654) | ![image](https://github.com/user-attachments/assets/7d2d8916-d799-4772-abe7-f86c6157be89) | ![image](https://github.com/user-attachments/assets/8999f7e2-f913-4562-b061-ffd244175e96) |

After (Android versions):
| 5 | 14 | 15 - 16 |
| --- | --- | --- |
| ![image](https://github.com/user-attachments/assets/9f90d12c-659c-41bd-a57d-423f030b183a) | ![image](https://github.com/user-attachments/assets/2b2f961f-84bf-4674-8d7b-ad775dc37945) | ![image](https://github.com/user-attachments/assets/7077b907-d477-4603-97bd-c7d73e27734c) |

14 dark mode:
| Before | After |
| --- | --- |
| ![image](https://github.com/user-attachments/assets/f62d76b6-95a3-4812-a418-90bf146a2502) | ![image](https://github.com/user-attachments/assets/82bd72c7-1f02-4a36-b362-53924d343ed4) |