### PR TITLE
fix null contentLength error

### DIFF
--- a/app/src/main/java/com/antony/muzei/pixiv/provider/network/interceptor/ImageIntegrityInterceptor.kt
+++ b/app/src/main/java/com/antony/muzei/pixiv/provider/network/interceptor/ImageIntegrityInterceptor.kt
@@ -31,7 +31,7 @@ class ImageIntegrityInterceptor : Interceptor {
             Log.d("LENGTH", "Reported length: $contentLength")
             Log.d("LENGTH", "Actual length: $responseLength")
 
-            if (contentLength == responseLength) {
+            if (contentLength == null || contentLength == responseLength) {
                 return response
             }
             response = chain.proceed(chain.request())


### PR DESCRIPTION
When downloading images, the response header sometimes doesn't have Content-Length (chunked response was used instead). This will cause the downloader to redownload the image 3 times before eventually fail.

```
Server: nginx
Date: Fri, 07 Nov 2025 10:55:03 GMT
Content-Type: image/jpeg
Transfer-Encoding: chunked
Connection: keep-alive
Cache-Control: max-age=31536000
Expires: Sat, 07 Nov 2026 10:55:02 GMT
Last-Modified: Sun, 23 Apr 2023 04:23:16 GMT
X-Content-Type-Options: nosniff
Age: 2
Via: http/1.1 f014 (second), http/1.1 f051 (second)
                                                                                                    
D  Reported length: null
D  Actual length: 3980941
```