### PR TITLE
Show artwork title when bookmarking

### DIFF
--- a/app/src/main/java/com/antony/muzei/pixiv/provider/AddToBookmarkService.kt
+++ b/app/src/main/java/com/antony/muzei/pixiv/provider/AddToBookmarkService.kt
@@ -78,15 +78,17 @@ class AddToBookmarkService : Service() {
                     .post(formBody)
                     .build()
 
+                val artworkTitle = intent.getStringExtra("artworkTitle") ?: ""
+
                 imageHttpClient.newCall(request).execute().use { response ->
                     if (response.isSuccessful) {
                         PixivMuzeiSupervisor.post(Runnable {
                             Toast.makeText(
                                 applicationContext,
                                 if (intent.getBooleanExtra("isPrivate", false))
-                                    R.string.toast_bookmark_private_success
+                                    applicationContext.getString(R.string.toast_bookmark_private_success, artworkTitle)
                                 else
-                                    R.string.toast_bookmark_success,
+                                    applicationContext.getString(R.string.toast_bookmark_success, artworkTitle),
                                 Toast.LENGTH_SHORT
                             ).show()
                         })
@@ -94,7 +96,7 @@ class AddToBookmarkService : Service() {
                         PixivMuzeiSupervisor.post(Runnable {
                             Toast.makeText(
                                 applicationContext,
-                                R.string.toast_bookmark_failure,
+                                applicationContext.getString(R.string.toast_bookmark_failure, artworkTitle),
                                 Toast.LENGTH_SHORT
                             ).show()
                         })

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -103,9 +103,9 @@
     <string name="toast_newFilterSelect">过滤选择更新，清除图像缓存</string>
     <string name="toast_newTag">搜索标签更新，清除图像缓存</string>
     <string name="toast_newUpdateMode">模式更新，清除图像缓存</string>
-    <string name="toast_bookmark_success">收藏成功</string>
-    <string name="toast_bookmark_private_success">非公开收藏成功</string>
-    <string name="toast_bookmark_failure">收藏失败</string>
+    <string name="toast_bookmark_success">收藏成功: %s</string>
+    <string name="toast_bookmark_private_success">非公开收藏成功: %s</string>
+    <string name="toast_bookmark_failure">收藏失败: %s</string>
 
     <string name="login_pixiv_refresh_hint">刷新令牌</string>
     <string name="action_sign_in_refresh">刷新令牌以登录</string><!--Refresh Token 用作刷新 Access Token，为 OAuth 中一项术语，此处翻译不确定-->

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -106,9 +106,9 @@
     <string name="toast_newFilterSelect">New filter selection, clearing image cache</string>
     <string name="toast_newTag">New search tag, clearing image cache</string>
     <string name="toast_newUpdateMode">New update mode, clearing image cache</string>
-    <string name="toast_bookmark_success">Added to bookmarks</string>
-    <string name="toast_bookmark_private_success">Added to private bookmarks</string>
-    <string name="toast_bookmark_failure">Failed to add to bookmarks</string>
+    <string name="toast_bookmark_success">Added to bookmarks: %s</string>
+    <string name="toast_bookmark_private_success">Added to private bookmarks: %s</string>
+    <string name="toast_bookmark_failure">Failed to add to bookmarks: %s</string>
 
     <string name="preferenceScreen">preferenceScreen</string>
     <string name="login_pixiv_refresh_hint">Refresh Token</string>


### PR DESCRIPTION
Currently, after the device has been idle and the wallpaper changed by Muzei, there is a probability (~33%) that the command buttons (e.g. Share, Bookmark, Show details) on the artwork in Muzei will actually operate on a previously displayed image instead of the current one. The only button that always works correctly is clicking the artwork title, which always opens the correct art webpage.

> I can confirm that this is a Muzei bug, as it also occurs with other sources (e.g. [The Verge Wallpapers](https://github.com/sal0max/muzei-thevergewallpapers)). I'm still trying to find the root cause, but the difficulty to reproduce makes it hard.

If the user clicks the share button, the wrong image will be shown in the share pop up, making this obvious. However, if they click the bookmark button, they might unknowingly bookmark the wrong image.

This PR adds the artwork title to the toast notification to help users make sure which image they are bookmarking.