### PR TITLE
Guard external-URL launch and log WebView load errors in login flow

### DIFF
--- a/app/src/main/java/com/antony/muzei/pixiv/login/LoginActivityWebview.kt
+++ b/app/src/main/java/com/antony/muzei/pixiv/login/LoginActivityWebview.kt
@@ -25,14 +25,17 @@
 package com.antony.muzei.pixiv.login
 
 import android.annotation.SuppressLint
+import android.content.ActivityNotFoundException
 import android.content.Intent
 import android.net.Uri
 import android.os.Bundle
 import android.util.Base64
 import android.util.Log
+import android.webkit.WebResourceError
 import android.webkit.WebResourceRequest
 import android.webkit.WebView
 import android.webkit.WebViewClient
+import android.widget.Toast
 import androidx.activity.enableEdgeToEdge
 import androidx.preference.PreferenceManager
 import com.antony.muzei.pixiv.BuildConfig
@@ -124,12 +127,23 @@ class LoginActivityWebview : PixivMuzeiActivity(),
                     if (url.host == "socialize.gigya.com") {
                         bypassDomainCheck = true
                     } else if (!bypassDomainCheck) {
-                        startActivity(Intent(Intent.ACTION_VIEW, url))
+                        try {
+                            startActivity(Intent(Intent.ACTION_VIEW, url))
+                        } catch (e: ActivityNotFoundException) {
+                            Log.w("LOGIN", "No app available to open $url", e)
+                            Toast.makeText(this@LoginActivityWebview, R.string.no_browser_available, Toast.LENGTH_LONG).show()
+                        }
                         return true
                     }
                 } else if (bypassDomainCheck)
                     bypassDomainCheck = false // Enable check if back to pixiv.
                 return false
+            }
+
+            override fun onReceivedError(view: WebView?, request: WebResourceRequest?, error: WebResourceError?) {
+                if (request != null && request.isForMainFrame) {
+                    Log.w("LOGIN", "WebView load error ${error?.errorCode}: ${error?.description} @ ${request.url}")
+                }
             }
         }
         val (code, hash) = generateCodeAndHash()

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -121,4 +121,5 @@
     <string name="prefSummary_enableNetworkBypass">Disable if you are having problems on VPN</string>
     <string name="prefSummary_usePixivCat">May speed up image downloads in some areas</string>
     <string name="prefTitle_tagLanguage">Tag language</string>
+    <string name="no_browser_available">No app available to open this link</string>
 </resources>


### PR DESCRIPTION
Closes #261

### What this does

1. Wraps the external `startActivity(Intent.ACTION_VIEW, url)` in `LoginActivityWebview.shouldOverrideUrlLoading` with `try { ... } catch (ActivityNotFoundException) { ... }` and shows a Toast on miss. Adds one string `no_browser_available`.
2. Adds an `onReceivedError(...)` override that logs error code, description and URL for main-frame loads only, so sub-resource failures do not flood the log.

### Why

The crash path is reachable on emulators and locked-down devices where no app handles a given URL scheme. The login activity has no other safety net there, so the user sees the app die mid-flow.

The error logging covers the "blank login page" support case, which is currently invisible because the WebView swallows the load failure and there is no toast or log line to point at.

No functional change to the happy path. The token exchange logic is untouched.
