### PR TITLE
Catch ActivityNotFoundException in login WebView URL handoff

### DIFF
--- a/app/src/main/java/com/antony/muzei/pixiv/login/LoginActivityWebview.kt
+++ b/app/src/main/java/com/antony/muzei/pixiv/login/LoginActivityWebview.kt
@@ -25,6 +25,7 @@
 package com.antony.muzei.pixiv.login
 
 import android.annotation.SuppressLint
+import android.content.ActivityNotFoundException
 import android.content.Intent
 import android.net.Uri
 import android.os.Bundle
@@ -33,6 +34,7 @@ import android.util.Log
 import android.webkit.WebResourceRequest
 import android.webkit.WebView
 import android.webkit.WebViewClient
+import android.widget.Toast
 import androidx.activity.enableEdgeToEdge
 import androidx.preference.PreferenceManager
 import com.antony.muzei.pixiv.BuildConfig
@@ -124,7 +126,16 @@ class LoginActivityWebview : PixivMuzeiActivity(),
                     if (url.host == "socialize.gigya.com") {
                         bypassDomainCheck = true
                     } else if (!bypassDomainCheck) {
-                        startActivity(Intent(Intent.ACTION_VIEW, url))
+                        try {
+                            startActivity(Intent(Intent.ACTION_VIEW, url))
+                        } catch (e: ActivityNotFoundException) {
+                            Log.w("LOGIN", "No handler for $url", e)
+                            Toast.makeText(
+                                this@LoginActivityWebview,
+                                R.string.no_app_to_open_link,
+                                Toast.LENGTH_LONG
+                            ).show()
+                        }
                         return true
                     }
                 } else if (bypassDomainCheck)

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -121,4 +121,5 @@
     <string name="prefSummary_enableNetworkBypass">Disable if you are having problems on VPN</string>
     <string name="prefSummary_usePixivCat">May speed up image downloads in some areas</string>
     <string name="prefTitle_tagLanguage">Tag language</string>
+    <string name="no_app_to_open_link">No app available to open this link</string>
 </resources>


### PR DESCRIPTION
Closes #263.

## Summary

`LoginActivityWebview.shouldOverrideUrlLoading` forwards every off-allowlist URL out to the system with `startActivity(Intent(Intent.ACTION_VIEW, url))`. If the device has no installed app that can handle the URI, that call throws `ActivityNotFoundException` and crashes the login Activity. This PR wraps the launch in try / catch, logs the failure, and shows a Toast (`R.string.no_app_to_open_link`).

## Changes

- `LoginActivityWebview.kt` -- wrap the `startActivity` call in try / catch and Toast on failure. Added imports for `ActivityNotFoundException` and `Toast`.
- `res/values/strings.xml` -- new `no_app_to_open_link` string used by the Toast.

## Behaviour after the patch

- Happy path is unchanged: an installed handler opens the URL as before, the WebView callback returns true.
- Missing handler: the user sees a Toast `No app available to open this link` and the login screen stays alive so they can keep going through the OAuth flow.

## How to reproduce the original crash

On a device / emulator with no app that handles `https://`:

1. Disable the system browser (`pm disable com.android.chrome` on emulator, or use a stripped GSI build).
2. Open the Muzei -> Pixiv login screen.
3. Tap any external link rendered on the Pixiv login page (for example the Pixiv Terms / Privacy footer link).

Before this PR the Activity crashes with `ActivityNotFoundException`. With this PR a Toast appears and the WebView stays on the login page.